### PR TITLE
add support for DNS based ACLs

### DIFF
--- a/dataprovider/bolt.go
+++ b/dataprovider/bolt.go
@@ -180,3 +180,19 @@ func (p *BoltProvider) UpdateUser(u *User) error {
 		return e
 	})
 }
+
+func (p *BoltProvider) GetAllUsers() (users []User, err error) {
+	err = p.dbHandle.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(userBucket)
+		c := b.Cursor()
+		for id, userBytes := c.First(); id != nil; id, userBytes = c.Next() {
+			var user User
+			err = json.Unmarshal(userBytes, &user)
+			if err == nil {
+				users = append(users, user)
+			}
+		}
+		return nil
+	})
+	return
+}

--- a/dataprovider/dataprovider.go
+++ b/dataprovider/dataprovider.go
@@ -20,6 +20,7 @@ type Provider interface {
 	RemoveUser(u *User) error
 	GetUser(id string) (*User, error)
 	UpdateUser(u *User) error
+	GetAllUsers() ([]User, error)
 
 	// only needs a real implementation if provider does not
 	// natively support TTL

--- a/dataprovider/ddns.go
+++ b/dataprovider/ddns.go
@@ -1,0 +1,119 @@
+package dataprovider
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	validate "github.com/asaskevich/govalidator"
+)
+
+type DdnsProvider struct {
+	fqdns      map[string]ACL
+	acls       map[string]ACL
+	lock       *sync.Mutex // TODO: use RWMutex
+	stopSignal chan bool
+}
+
+func NewDdnsProvider() (p DdnsProvider) {
+	p = DdnsProvider{
+		fqdns:      make(map[string]ACL),
+		acls:       make(map[string]ACL),
+		lock:       new(sync.Mutex),
+		stopSignal: make(chan bool),
+	}
+	go p.daemonize()
+	log.Debug("ddns provider has been initialized")
+	return
+}
+
+func (p *DdnsProvider) ProcessUsers(users []User) {
+	log.Debugf("processing %d user(s)", len(users))
+	for _, user := range users {
+		p.ProcessUser(&user)
+	}
+}
+
+func (p *DdnsProvider) ProcessUser(user *User) {
+	if len(user.DNSNames) == 0 {
+		return
+	}
+	log.Debugf("user %s has %d DNS Names", user.ID, len(user.DNSNames))
+	p.lock.Lock()
+	for _, fqdn := range user.DNSNames {
+		if validate.IsDNSName(fqdn) {
+			p.fqdns[fqdn] = ACL{
+				AllowAll:     user.ACLAllowAll,
+				AllowedHosts: user.ACLAllowedHosts,
+			}
+		}
+	}
+	p.lock.Unlock()
+	p.updateACLs()
+}
+
+func (p *DdnsProvider) DeleteUser(user *User) {
+	if len(user.DNSNames) == 0 {
+		return
+	}
+	p.lock.Lock()
+	for _, fqdn := range user.DNSNames {
+		if _, ok := p.fqdns[fqdn]; ok {
+			delete(p.fqdns, fqdn)
+		}
+	}
+	p.lock.Unlock()
+	p.updateACLs()
+}
+
+func (p *DdnsProvider) GetACL(ip string) (acl *ACL) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if aclFound, ok := p.acls[ip]; ok {
+		acl = &aclFound
+	}
+	return
+}
+
+func (p *DdnsProvider) updateACLs() {
+	if len(p.fqdns) == 0 {
+		return
+	}
+	acls := make(map[string]ACL)
+	for fqdn, acl := range p.fqdns {
+		ips, err := net.LookupIP(fqdn)
+		if err != nil {
+			log.Errorf("unable to perform a DNS lookup for %s: %v", fqdn, err)
+		}
+		if len(ips) > 0 {
+			// we ONLY use the first IP address, and ignore everything else
+			if len(ips) > 1 {
+				log.Warningf("the following dns lookup (%s) resulted in more than one (%d) IPs. Only using the first one %s", fqdn, len(ips), ips[0])
+			}
+			acls[ips[0].String()] = acl
+		}
+	}
+	log.Debugf("adding %d ACLs", len(acls))
+	p.lock.Lock()
+	p.acls = acls
+	p.lock.Unlock()
+}
+
+// daemonize is a blocking loop which periodically updates ACLs. Only exits if shutdown signal is received
+func (p *DdnsProvider) daemonize() {
+	// for now, hard code this interval
+	updateInterval := 120
+	t := time.Tick(time.Duration(updateInterval) * time.Minute)
+	log.Infof("interval of periodic updates for DNS based ACLs is set to %d minute(s)", updateInterval)
+
+	for {
+		select {
+		case <-t:
+			p.updateACLs()
+			log.Debugf("periodic update for DNS based ACLs completed")
+		case <-p.stopSignal:
+			log.Warning("stop signal received, DNS based ACLs will stop being updated.")
+			return
+		}
+	}
+}

--- a/dataprovider/memory.go
+++ b/dataprovider/memory.go
@@ -126,6 +126,15 @@ func (p *MemoryProvider) GetUser(id string) (user *User, err error) {
 	return
 }
 
+func (p *MemoryProvider) GetAllUsers() (users []User, err error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	for _, user := range p.users {
+		users = append(users, user)
+	}
+	return
+}
+
 func (p *MemoryProvider) UpdateUser(u *User) error {
 	// validate the user object
 	if u == nil || len(u.ID) < 6 {

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,7 @@ import (
 var (
 	log          = config.GetLogger()
 	dataProvider dataprovider.Provider
+	ddnsProvider dataprovider.DdnsProvider
 
 	// set timeouts to avoid Slowloris attacks.
 	httpWriteTimeout = time.Second * 15
@@ -66,6 +67,15 @@ func InitServer(p dataprovider.Provider) error {
 	}
 	// set the data provider
 	dataProvider = p
+	// set the dynamic dns provider
+	ddnsProvider = dataprovider.NewDdnsProvider()
+	// populate any existing users from dataprovider into ddnsprovider
+	users, err := dataProvider.GetAllUsers()
+	if err != nil {
+		return err
+	}
+	ddnsProvider.ProcessUsers(users)
+	// start http server
 	return startHTTPServer()
 }
 

--- a/testdata/scripts/update_user.sh
+++ b/testdata/scripts/update_user.sh
@@ -23,4 +23,5 @@ http --print=HhBb PUT ${URL}/5e8848 ADMIN-SECRET:supersecret \
   secret="password" \
   acl_allow_all:=false \
   ttl_minutes:=10 \
-  acl_allowed_hosts:='["git.fqdn","emby.fqdn"]'
+  acl_allowed_hosts:='["git.fqdn","emby.fqdn"]' \
+  dns_names:='["google.com","linuxctl.com"]'


### PR DESCRIPTION
when a user object has DNS name(s) accosicated with them, we will peridically do lookups for the IPs and add them to the ACL without TTL. Also when the IP of the DNS name changes, the old IP gets removed.